### PR TITLE
Add Godot 4.1 Support

### DIFF
--- a/demo/addons/godot-git-plugin/git_plugin.gdextension
+++ b/demo/addons/godot-git-plugin/git_plugin.gdextension
@@ -1,6 +1,7 @@
 [configuration]
 
 entry_symbol = "git_plugin_init"
+compatibility_minimum = "4.1.0"
 
 [libraries]
 

--- a/demo/addons/godot-git-plugin/plugin.cfg
+++ b/demo/addons/godot-git-plugin/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot Git Plugin"
 description="This plugin lets you interact with Git without leaving the Godot editor. More information can be found at https://github.com/godotengine/godot-git-plugin/wiki"
 author="twaritwaikar"
-version="v3.0.0-beta1"
+version="v3.0.1"
 script="godot-git-plugin.gd"

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -10,7 +10,7 @@ config_version=5
 
 [application]
 
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 
 [editor]
 

--- a/godot-git-plugin/src/gdlibrary.cpp
+++ b/godot-git-plugin/src/gdlibrary.cpp
@@ -19,8 +19,8 @@ void uninitialize_git_plugin_module(godot::ModuleInitializationLevel p_level) {
 
 extern "C" {
 
-GDExtensionBool GDE_EXPORT git_plugin_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-	godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+GDExtensionBool GDE_EXPORT git_plugin_init(const GDExtensionInterfaceGetProcAddress p_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+	godot::GDExtensionBinding::InitObject init_obj(p_address, p_library, r_initialization);
 
 	init_obj.register_initializer(initialize_git_plugin_module);
 	init_obj.register_terminator(uninitialize_git_plugin_module);


### PR DESCRIPTION
- Update godot-cpp
- Fix Entry Point that changed within Godot 4.1
- Add compatibility_minimum to gdextension required for 4.1 support
- Bump version in plugin.cfg
- Upgrade demo project to 4.1
- Made by @jokoho48